### PR TITLE
Publish to mavenCentral() with plugin

### DIFF
--- a/.github/workflows/Android-CI.yml
+++ b/.github/workflows/Android-CI.yml
@@ -48,6 +48,14 @@ jobs:
       - uses: gradle/actions/wrapper-validation@v5
       - name: Install Android SDK
         uses: hannesa2/action-android/install-sdk@0.1.16.7
+      - name: Build project
+        run: ./gradlew assembleDebug
+      - name: Deploy test (Don't merge)
+        run: ./gradlew publishMavenPublicationToMavenRepository
+      - name: Run tests
+        run: ./gradlew test
+      - name: Test jitpack publish command
+        run: ./gradlew :MPChartLib:publishToMavenLocal
       - name: Run instrumentation tests
         uses: hannesa2/action-android/emulator-run-cmd@0.1.16.7
         with:

--- a/MPChartLib/build.gradle
+++ b/MPChartLib/build.gradle
@@ -53,10 +53,10 @@ dependencies {
     testImplementation "junit:junit:4.13.2"
 }
 
-tasks.register("androidSourcesJar", Jar) {
-    archiveClassifier.set("sources")
-    from android.sourceSets.main.java.srcDirs
-}
+//tasks.register("androidSourcesJar", Jar) {
+//    archiveClassifier.set("sources")
+//    from android.sourceSets.main.java.srcDirs
+//}
 
 group = "info.mxtracks"
 version = "${getTag()}"

--- a/MPChartLib/build.gradle
+++ b/MPChartLib/build.gradle
@@ -5,6 +5,8 @@ plugins {
     id "com.vanniktech.maven.publish" version "0.34.0"
 }
 
+apply from: 'https://raw.github.com/chrisbanes/gradle-mvn-push/master/gradle-mvn-push.gradle'
+
 ext {
     mGroupId = "info.appdevnext"
     mArtifactId = "chart"

--- a/MPChartLib/gradle.properties
+++ b/MPChartLib/gradle.properties
@@ -1,0 +1,3 @@
+POM_NAME=Andorid Chart
+POM_ARTIFACT_ID=library
+POM_PACKAGING=aar

--- a/gradle.properties
+++ b/gradle.properties
@@ -9,3 +9,19 @@ RELEASE_SIGNING_ENABLED=true
 POM_ARTIFACT_ID=chart
 android.nonTransitiveRClass=false
 android.nonFinalResIds=false
+
+# TODO use right, and currently unknown, credentials
+VERSION_NAME=0.9.2-SNAPSHOT
+VERSION_CODE=92
+GROUP=info.mxtracks
+
+POM_DESCRIPTION=A powerful Android chart view / graph view library, supporting line- bar- pie- radar- bubble- and candlestick charts as well as scaling, dragging and animations.
+POM_URL=https://github.com/AppDevNext/AndroidChart
+POM_SCM_URL=https://github.com/AppDevNext/AndroidChart
+POM_SCM_CONNECTION=scm:git@github.com:AppDevNext/AndroidChart.git
+POM_SCM_DEV_CONNECTION=scm:git@github.com:AppDevNext/AndroidChart.git
+POM_LICENCE_NAME=The Apache Software License, Version 2.0
+POM_LICENCE_URL=http://www.apache.org/licenses/LICENSE-2.0.txt
+POM_LICENCE_DIST=repo
+POM_DEVELOPER_ID=hannesa2
+POM_DEVELOPER_NAME=Hannes A


### PR DESCRIPTION
### New tasks:
`publishAllPublicationsToMavenRepository` - Publishes all Maven publications produced by this project to the maven repository. 
`publishMavenPublicationToMavenRepository` - Publishes Maven publication 'maven' to Maven repository 'maven'.