### PR TITLE
Fixes zoomAndCenterAnimated did not center on coordinates

### DIFF
--- a/MPChartLib/src/main/java/com/github/mikephil/charting/jobs/AnimatedZoomJob.java
+++ b/MPChartLib/src/main/java/com/github/mikephil/charting/jobs/AnimatedZoomJob.java
@@ -35,6 +35,10 @@ public class AnimatedZoomJob extends AnimatedViewPortJob implements Animator.Ani
         result.yOrigin = yOrigin;
         result.yAxis = axis;
         result.xAxisRange = xAxisRange;
+        result.zoomCenterX = zoomCenterX;
+        result.zoomCenterY = zoomCenterY;
+        result.zoomOriginX = zoomOriginX;
+        result.zoomOriginY = zoomOriginY;
         result.resetAnimator();
         result.animator.setDuration(duration);
         return result;


### PR DESCRIPTION
Fixes issue [#4334](https://github.com/PhilJay/MPAndroidChart/issues/4334) where zoomAndCenterAnimated did not center on coordinates.

In static method AnimatedZoomJob:getInstance added the assignment of the parameters zoomCenterX, zoomCenterY, zoomOriginX, zoomOriginY.