### PR TITLE
Disable drawing a marker on data that has been set to not visible

### DIFF
--- a/MPChartLib/src/main/java/com/github/mikephil/charting/charts/Chart.java
+++ b/MPChartLib/src/main/java/com/github/mikephil/charting/charts/Chart.java
@@ -762,6 +762,9 @@ public abstract class Chart<T extends ChartData<? extends IDataSet<? extends Ent
 		for (Highlight highlight : mIndicesToHighlight) {
 
 			IDataSet set = mData.getDataSetByIndex(highlight.getDataSetIndex());
+			if (!set.isVisible()) {
+				continue;
+			}
 
 			Entry e = mData.getEntryForHighlight(highlight);
 


### PR DESCRIPTION
Currently markers are drawn for data even if it is set to be invisible. This ignores any markers for data that is invisible.