### PR TITLE
Prevent crash when updating datasets and calling animation functions

### DIFF
--- a/MPChartLib/src/main/java/com/github/mikephil/charting/charts/Chart.java
+++ b/MPChartLib/src/main/java/com/github/mikephil/charting/charts/Chart.java
@@ -761,8 +761,10 @@ public abstract class Chart<T extends ChartData<? extends IDataSet<? extends Ent
 
 		for (Highlight highlight : mIndicesToHighlight) {
 
+			// When changing data sets and calling animation functions, sometimes an erroneous highlight is generated
+			// on the dataset that is removed. Null check to prevent crash
 			IDataSet set = mData.getDataSetByIndex(highlight.getDataSetIndex());
-			if (!set.isVisible()) {
+			if (set == null || !set.isVisible()) {
 				continue;
 			}
 


### PR DESCRIPTION
Sometimes, when changing datasets and then animating, an erroneous highlight is generated for the removed dataset. Null check prevents crash (interestingly the iOS lib had the same issue)