### PR TITLE
Fix OOM when create DefaultAxisValueFormatter

### DIFF
--- a/MPChartLib/src/main/java/com/github/mikephil/charting/renderer/AxisRenderer.kt
+++ b/MPChartLib/src/main/java/com/github/mikephil/charting/renderer/AxisRenderer.kt
@@ -211,7 +211,7 @@ abstract class AxisRenderer(
         }
 
         // set decimals
-        if (interval < 1) {
+        if (interval > 0 && interval < 1) {
             axis.mDecimals = ceil(-log10(interval)).toInt()
         } else {
             axis.mDecimals = 0


### PR DESCRIPTION
It seems that when `max` and `min` are not set, the `AxisBase.mDecimals` is updated to infinity and thus cause Out Of Memory as `DefaultAxisValueFormatter` create a `StringBuffer`. There is a similar [issue](https://github.com/PhilJay/MPAndroidChart/issues/2219) opened in the original repo. 

Even though we can enable `granularity` to prevent this, I think it's better to have a guard in case developers are not aware of the `granularity` option. Hence, I have copied the propose change here.