### PR TITLE
EntryDouble test

### DIFF
--- a/chartLib/build.gradle.kts
+++ b/chartLib/build.gradle.kts
@@ -43,6 +43,8 @@ dependencies {
     implementation("androidx.activity:activity-ktx:1.12.2")
     implementation("com.github.AppDevNext.Logcat:LogcatCoreLib:3.4")
     testImplementation("junit:junit:4.13.2")
+    testImplementation("org.mockito:mockito-core:5.21.0")
+    testImplementation("org.mockito:mockito-inline:5.2.0")
 }
 
 tasks.register<Jar>("androidSourcesJar") {

--- a/chartLib/src/main/kotlin/info/appdev/charting/data/EntryDouble.kt
+++ b/chartLib/src/main/kotlin/info/appdev/charting/data/EntryDouble.kt
@@ -1,0 +1,3 @@
+package info.appdev.charting.data
+
+class EntryDouble(val xDouble: Double, y: Float) : Entry(xDouble.toFloat(), y)

--- a/chartLib/src/test/kotlin/info/appdev/charting/test/FloatTest.kt
+++ b/chartLib/src/test/kotlin/info/appdev/charting/test/FloatTest.kt
@@ -1,0 +1,31 @@
+package info.appdev.charting.test
+
+import org.junit.Assert
+import org.junit.Test
+
+class FloatTest {
+
+
+    @Test
+    fun testFloatConversion() {
+        val timestamp: Long = System.currentTimeMillis()
+
+        // 2) Cast to Float and back
+        val asFloat: Float = timestamp.toFloat()
+        val roundTripFromFloat: Long = asFloat.toLong()
+
+        // 3) Cast to Double and back
+        val asDouble: Double = timestamp.toDouble()
+        val roundTripFromDouble: Long = asDouble.toLong()
+
+        println("Original timestamp:       $timestamp")
+        println("→ as Float:               $asFloat")
+        println("→ back to Long (Float):   $roundTripFromFloat")
+        println()
+        println("→ as Double:              $asDouble")
+        println("→ back to Long (Double):  $roundTripFromDouble")
+        println()
+        Assert.assertNotEquals(timestamp, roundTripFromFloat)
+        Assert.assertEquals(timestamp, roundTripFromDouble)
+    }
+}


### PR DESCRIPTION
With this there is a test to demonstrate the issue https://github.com/AppDevNext/AndroidChart/issues/197 and you will see this

```
Original timestamp:       1767089724395
→ as Float:               1.76708977E12
→ back to Long (Float):   1767089766400

→ as Double:              1.767089724395E12
→ back to Long (Double):  1767089724395
```
