### PR TITLE
Fix BarChart crash

### DIFF
--- a/chartLib/src/main/kotlin/info/appdev/charting/data/BarDataSet.kt
+++ b/chartLib/src/main/kotlin/info/appdev/charting/data/BarDataSet.kt
@@ -193,8 +193,4 @@ open class BarDataSet(yVals: MutableList<BarEntry>, label: String) : BarLineScat
         set(value) {
             mStackLabels = value
         }
-
-    override fun getEntryIndex(entry: BarEntry): Int {
-        return this.getEntryIndex(entry)
-    }
 }


### PR DESCRIPTION
Fixes BarChart crash when clicking on any bar.
The crash was caused by getEntryIndex invoking itself instead of the superclass function.