### PR TITLE
copy: Corrected touch target boundaries for various chart types

### DIFF
--- a/app/build.gradle.kts
+++ b/app/build.gradle.kts
@@ -1,9 +1,10 @@
-import info.git.versionHelper.getGitCommitCount
-import info.git.versionHelper.getVersionText
+//import info.git.versionHelper.getGitCommitCount
+//import info.git.versionHelper.getVersionText
 import org.jetbrains.kotlin.gradle.dsl.JvmTarget
 
 plugins {
     id("com.android.application")
+    id("org.jetbrains.kotlin.android")
     id("org.jetbrains.kotlin.plugin.compose") version "2.4.0"
 }
 
@@ -14,8 +15,8 @@ android {
         minSdk = 23
         compileSdk = 35
         targetSdk = 35
-        versionCode = getGitCommitCount()
-        versionName = getVersionText()
+        versionCode = 1
+        versionName = "1.0.0"
         testInstrumentationRunner = "androidx.test.runner.AndroidJUnitRunner"
         testInstrumentationRunnerArguments.putAll(
             mapOf(
@@ -26,11 +27,6 @@ android {
     compileOptions {
         sourceCompatibility = JavaVersion.VERSION_17
         targetCompatibility = JavaVersion.VERSION_17
-    }
-    kotlin {
-        compilerOptions {
-            jvmTarget = JvmTarget.JVM_17
-        }
     }
     buildFeatures {
         viewBinding = true
@@ -55,6 +51,12 @@ android {
             // keep it as-is to silence "Unable to strip" warnings.
             keepDebugSymbols += "**/libandroidx.graphics.path.so"
         }
+    }
+}
+
+kotlin {
+    compilerOptions {
+        jvmTarget.set(JvmTarget.JVM_17)
     }
 }
 

--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -4,10 +4,8 @@ buildscript {
         mavenCentral()
     }
     dependencies {
-        // Lint API version tracks AGP: AGP 9.1.1 → Lint 32.1.1
-        // in module lint:
-        // val lintVersion = "32.1.1"
-        classpath("com.android.tools.build:gradle:9.2.1")
+        // Lowering to a stable local AGP version to fix the sync environment
+        classpath("com.android.tools.build:gradle:8.13.0")
         classpath("com.github.dcendents:android-maven-gradle-plugin:2.1")
         classpath("org.jetbrains.kotlin:kotlin-gradle-plugin:2.4.0")
     }

--- a/chartLib/build.gradle.kts
+++ b/chartLib/build.gradle.kts
@@ -1,9 +1,10 @@
-import info.git.versionHelper.getVersionText
+//import info.git.versionHelper.getVersionText
 import org.jetbrains.kotlin.gradle.dsl.JvmTarget
 import java.net.URI
 
 plugins {
     id("com.android.library")
+    id("org.jetbrains.kotlin.android")
     id("maven-publish")
     id("com.vanniktech.maven.publish") version "0.37.0"
 }
@@ -16,7 +17,7 @@ android {
 
         // VERSION_NAME no longer available as of 4.1
         // https://issuetracker.google.com/issues/158695880
-        buildConfigField("String", "VERSION_NAME", "\"${getVersionText()}\"")
+        buildConfigField("String", "VERSION_NAME", "\"1.0.0\"")
 
         consumerProguardFiles.add(File("proguard-lib.pro"))
 
@@ -25,11 +26,6 @@ android {
     compileOptions {
         sourceCompatibility = JavaVersion.VERSION_17
         targetCompatibility = JavaVersion.VERSION_17
-    }
-    kotlin {
-        compilerOptions {
-            jvmTarget = JvmTarget.JVM_17
-        }
     }
     buildTypes {
         release {
@@ -48,6 +44,12 @@ android {
             // keep it as-is to silence "Unable to strip" warnings.
             keepDebugSymbols += "**/libandroidx.graphics.path.so"
         }
+    }
+}
+
+kotlin {
+    compilerOptions {
+        jvmTarget.set(JvmTarget.JVM_17)
     }
 }
 
@@ -77,7 +79,7 @@ tasks.register<Jar>("androidSourcesJar") {
 }
 
 group = project.findProperty("group")?.toString() ?: "info.AppDevNext"
-var versionVersion = getVersionText()
+var versionVersion = "1.0.0"
 println("Build version $versionVersion")
 
 mavenPublishing {

--- a/chartLib/src/main/kotlin/info/appdev/charting/data/BarEntryFloat.kt
+++ b/chartLib/src/main/kotlin/info/appdev/charting/data/BarEntryFloat.kt
@@ -198,20 +198,21 @@ open class BarEntryFloat : EntryFloat {
         if (values == null || values.isEmpty())
             return
 
-        this.ranges = arrayOf()
+        this.ranges = Array(values.size) { Range(0f, 0f) }
 
         var negRemain = -this.negativeSum
         var posRemain = 0f
 
-        for (i in ranges.indices) {
+        for (i in values.indices) {
             val value = values[i]
 
             if (value < 0) {
                 this.ranges[i] = Range(negRemain, negRemain - value)
                 negRemain -= value
             } else {
-                this.ranges[i] = Range(posRemain, posRemain + value)
-                posRemain += value
+                val nextPos = posRemain + value
+                this.ranges[i] = Range(posRemain, nextPos)
+                posRemain = nextPos
             }
         }
     }

--- a/chartLib/src/main/kotlin/info/appdev/charting/highlight/BarHighlighter.kt
+++ b/chartLib/src/main/kotlin/info/appdev/charting/highlight/BarHighlighter.kt
@@ -1,95 +1,197 @@
 package info.appdev.charting.highlight
 
+import android.annotation.SuppressLint
+import info.appdev.charting.components.YAxis.AxisDependency
+import info.appdev.charting.data.BarData
+import info.appdev.charting.data.BarEntryFloat
+import info.appdev.charting.data.DataSet
 import info.appdev.charting.interfaces.dataprovider.BarDataProvider
 import info.appdev.charting.interfaces.datasets.IBarDataSet
+import info.appdev.charting.interfaces.datasets.IDataSet
 import info.appdev.charting.utils.PointD
 import kotlin.math.abs
-import kotlin.math.max
 
 open class BarHighlighter(barDataProvider: BarDataProvider) : ChartHighlighter<BarDataProvider>(barDataProvider) {
+
     override fun getHighlight(x: Float, y: Float): Highlight? {
-        val high = super.getHighlight(x, y) ?: return null
+        val barData = provider.barData ?: return null
 
+        // 1. Convert touch pixel to chart coordinates
         val pos = getValsForTouch(x, y)
+        val xVal = pos.x.toFloat()
 
-        provider.barData?.let { barData ->
-            barData.getDataSetByIndex(high.dataSetIndex)?.let { set ->
-                if (set.isStacked) {
-                    return getStackedHighlight(
-                        high,
-                        set,
-                        pos.x.toFloat(),
-                        pos.y.toFloat()
-                    )
+        // 2. Resolve the closest base highlight using our overridden buildHighlights loop
+        val high = getHighlightForX(xVal, x, y) ?: run {
+            PointD.recycleInstance(pos)
+            return null
+        }
+
+        val set = barData.getDataSetByIndex(high.dataSetIndex) ?: run {
+            PointD.recycleInstance(pos)
+            return null
+        }
+
+        // 3. Stacked Chart processing
+        if (set.isStacked) {
+            val stackedHighlight = getStackedHighlight(
+                high,
+                set,
+                pos.x.toFloat(),
+                pos.y.toFloat()
+            )
+            PointD.recycleInstance(pos)
+            return stackedHighlight
+        }
+
+        // 4. Non-Stacked Chart data bounds check
+        val entry = set.getEntryForXValue(high.x, high.y) as? BarEntryFloat
+        if (entry != null) {
+            val barWidthHalf = barData.barWidth / 2f
+            val barLeft = entry.x - barWidthHalf
+            val barRight = entry.x + barWidthHalf
+
+            if (pos.x < barLeft || pos.x > barRight) {
+                PointD.recycleInstance(pos)
+                return null
+            }
+
+            val valY = entry.y
+            if (valY >= 0) {
+                if (pos.y > valY || pos.y < 0) {
+                    PointD.recycleInstance(pos)
+                    return null
+                }
+            } else {
+                if (pos.y < valY || pos.y > 0) {
+                    PointD.recycleInstance(pos)
+                    return null
                 }
             }
         }
-        PointD.recycleInstance(pos)
 
+        PointD.recycleInstance(pos)
         return high
     }
 
-    /**
-     * This method creates the Highlight object that also indicates which value of a stacked BarEntry has been
-     * selected.
-     *
-     * @param high the Highlight to work with looking for stacked values
-     */
-    fun getStackedHighlight(high: Highlight, set: IBarDataSet, xVal: Float, yVal: Float): Highlight? {
-        set.getEntryForXValue(xVal, yVal)?.let { entry ->
-            // not stacked
-            if (entry.yVals == null) {
-                return high
-            } else {
-                val ranges: Array<Range> = entry.ranges
+    override fun buildHighlights(
+        @SuppressLint("RawTypeDataSet") set: IDataSet<*>,
+        dataSetIndex: Int,
+        xVal: Float,
+        rounding: DataSet.Rounding?
+    ): MutableList<Highlight> {
+        val highlights = ArrayList<Highlight>()
 
-                if (ranges.isNotEmpty()) {
-                    val stackIndex = getClosestStackIndex(ranges, yVal)
+        // Cast safely to BarEntryFloat instead of breaking on EntryFloat mapping
+        var entries = set.getEntriesForXValue(xVal)?.map { it as BarEntryFloat }?.toMutableList()
 
-                    val pixels = provider.getTransformer(set.axisDependency)!!.getPixelForValues(high.x, ranges[stackIndex].to)
-
-                    val stackedHigh = Highlight(
-                        x = entry.x,
-                        y = entry.y,
-                        xPx = pixels.x.toFloat(),
-                        yPx = pixels.y.toFloat(),
-                        dataSetIndex = high.dataSetIndex,
-                        stackIndex = stackIndex,
-                        axis = high.axis
-                    )
-
-                    PointD.recycleInstance(pixels)
-
-                    return stackedHigh
-                }
+        if (entries.isNullOrEmpty()) {
+            val closest = set.getEntryForXValue(xVal, Float.NaN, rounding) as? BarEntryFloat
+            if (closest != null) {
+                entries = set.getEntriesForXValue(closest.x)?.map { it as BarEntryFloat }?.toMutableList()
             }
         }
-        return null
-    }
 
-    /**
-     * Returns the index of the closest value inside the values array / ranges (stacked barchart) to the value given as a parameter.
-     */
-    protected fun getClosestStackIndex(ranges: Array<Range>?, value: Float): Int {
-        if (ranges == null || ranges.isEmpty())
-            return 0
+        if (entries.isNullOrEmpty()) return highlights
 
-        var stackIndex = 0
-
-        for (range in ranges) {
-            if (range.contains(value))
-                return stackIndex
-            else
-                stackIndex++
+        for (e in entries) {
+            val pixels = provider.getTransformer(set.axisDependency)!!.getPixelForValues(e.x, e.y)
+            highlights.add(
+                Highlight(
+                    x = e.x,
+                    y = e.y,
+                    xPx = pixels.x.toFloat(),
+                    yPx = pixels.y.toFloat(),
+                    dataSetIndex = dataSetIndex,
+                    axis = set.axisDependency
+                )
+            )
+            PointD.recycleInstance(pixels)
         }
 
-        val length = max(ranges.size - 1, 0)
+        return highlights
+    }
 
-        return if (value > ranges[length].to) length else 0
+    open fun getStackedHighlight(high: Highlight, set: IBarDataSet, xVal: Float, yVal: Float): Highlight? {
+        val entry = set.getEntryForXValue(high.x, high.y) as? BarEntryFloat ?: return high
+        if (entry.yVals == null) return high
+
+        val ranges = entry.ranges
+        if (ranges.isNullOrEmpty()) return null
+
+        // FIX: Removed the artificial selection tolerance to prevent selections when clicking in-between gaps
+        val barWidthHalf = (provider.barData?.barWidth ?: 1f) / 2f
+
+        val isHorizontal = provider.javaClass.name.contains("HorizontalBarChart", ignoreCase = true)
+
+        if (isHorizontal) {
+            val barBottomEdge = entry.x - barWidthHalf
+            val barTopEdge = entry.x + barWidthHalf
+            if (xVal < barBottomEdge || xVal > barTopEdge) return null
+
+            val stackMin = ranges[0].from
+            val stackMax = ranges[ranges.size - 1].to
+            if (yVal < stackMin || yVal > stackMax) return null
+        } else {
+            val barLeftEdge = entry.x - barWidthHalf
+            val barRightEdge = entry.x + barWidthHalf
+            if (xVal < barLeftEdge || xVal > barRightEdge) return null
+
+            val stackBottom = ranges[0].from
+            val stackTop = ranges[ranges.size - 1].to
+            val valueOffset = 0.05f
+            if (entry.y >= 0) {
+                if (yVal > (stackTop + valueOffset) || yVal < -valueOffset) return null
+            } else {
+                if (yVal < (stackBottom - valueOffset) || yVal > valueOffset) return null
+            }
+        }
+
+        // FIX: Uniformly look up the segments along the value scale axis (yVal) for accurate layer picking
+        val stackIndex = getClosestStackIndex(ranges, yVal)
+        val pixels = if (isHorizontal) {
+            val highlightVal = if (ranges[stackIndex].from < 0) ranges[stackIndex].from else ranges[stackIndex].to
+            provider.getTransformer(set.axisDependency)!!.getPixelForValues(highlightVal, high.x)
+        } else {
+            provider.getTransformer(set.axisDependency)!!.getPixelForValues(high.x, ranges[stackIndex].to)
+        }
+
+        val stackedHigh = Highlight(
+            x = entry.x,
+            y = entry.y,
+            xPx = pixels.x.toFloat(),
+            yPx = pixels.y.toFloat(),
+            dataSetIndex = high.dataSetIndex,
+            stackIndex = stackIndex,
+            axis = high.axis
+        )
+
+        PointD.recycleInstance(pixels)
+        return stackedHigh
+    }
+
+    protected fun getClosestStackIndex(ranges: Array<Range>?, value: Float): Int {
+        if (ranges.isNullOrEmpty()) return 0
+
+        var stackIndex = 0
+        for (range in ranges) {
+            if (range.contains(value)) return stackIndex
+            else stackIndex++
+        }
+
+        var closest = 0
+        var closestDist = Float.MAX_VALUE
+        for (i in ranges.indices) {
+            val mid = (ranges[i].from + ranges[i].to) / 2f
+            val dist = abs(mid - value)
+            if (dist < closestDist) {
+                closestDist = dist
+                closest = i
+            }
+        }
+        return closest
     }
 
     override fun getDistance(x1: Float, y1: Float, x2: Float, y2: Float): Float {
         return abs(x1 - x2)
     }
-
 }

--- a/chartLib/src/main/kotlin/info/appdev/charting/highlight/ChartHighlighter.kt
+++ b/chartLib/src/main/kotlin/info/appdev/charting/highlight/ChartHighlighter.kt
@@ -12,8 +12,9 @@ import kotlin.math.abs
 import kotlin.math.hypot
 
 open class ChartHighlighter<T : BarLineScatterCandleBubbleDataProvider<*>>(protected var provider: T) : IHighlighter {
+
     /**
-     * buffer for storing previously highlighted values
+     * Buffer for storing previously highlighted values.
      */
     protected var highlightBuffer: MutableList<Highlight> = ArrayList()
 
@@ -27,12 +28,9 @@ open class ChartHighlighter<T : BarLineScatterCandleBubbleDataProvider<*>>(prote
     }
 
     /**
-     * Returns a recyclable PointD instance.
-     * Returns the corresponding xPos for a given touch-position in pixels.
+     * Returns a recyclable PointD instance matching the corresponding xPos for a given touch-position in pixels.
      */
     protected fun getValsForTouch(x: Float, y: Float): PointD {
-        // take any transformer to determine the x-axis value
-
         return provider.getTransformer(AxisDependency.LEFT)!!.getValuesByTouchPoint(x, y)
     }
 
@@ -42,7 +40,7 @@ open class ChartHighlighter<T : BarLineScatterCandleBubbleDataProvider<*>>(prote
     protected fun getHighlightForX(xVal: Float, x: Float, y: Float): Highlight? {
         val closestValues = getHighlightsAtXValue(xVal, x, y)
 
-        if (closestValues!!.isEmpty()) {
+        if (closestValues.isNullOrEmpty()) {
             return null
         }
 
@@ -51,12 +49,15 @@ open class ChartHighlighter<T : BarLineScatterCandleBubbleDataProvider<*>>(prote
 
         val axis = if (leftAxisMinDist < rightAxisMinDist) AxisDependency.LEFT else AxisDependency.RIGHT
 
-        return getClosestHighlightByPixel(closestValues, x, y, axis, provider.maxHighlightDistance)
+        // Match original architecture by passing the custom display metric density scaling directly
+        val density = (provider as? android.view.View)?.context?.resources?.displayMetrics?.density ?: 1f
+        val maxSelectionDistance = 40f * density
+
+        return getClosestHighlightByPixel(closestValues, x, y, axis, maxSelectionDistance)
     }
 
     /**
-     * Returns the minimum distance from a touch value (in pixels) to the
-     * closest value (in pixels) that is displayed in the chart.
+     * Returns the minimum distance from a touch value (in pixels) to the closest visible chart value.
      */
     protected fun getMinimumDistance(closestValues: MutableList<Highlight>, pos: Float, axis: AxisDependency?): Float {
         var distance = Float.MAX_VALUE
@@ -81,32 +82,22 @@ open class ChartHighlighter<T : BarLineScatterCandleBubbleDataProvider<*>>(prote
 
     /**
      * Returns a list of Highlight objects representing the entries closest to the given xVal.
-     * The returned list contains two objects per DataSet (closest rounding up, closest rounding down).
-     *
-     * @param xVal the transformed x-value of the x-touch position
-     * @param x    touch position
-     * @param y    touch position
      */
     override fun getHighlightsAtXValue(xVal: Float, x: Float, y: Float): MutableList<Highlight>? {
         highlightBuffer.clear()
 
-        data?.let { myData ->
-            var i = 0
-            val dataSetCount = myData.dataSetCount
-            while (i < dataSetCount) {
-                val dataSet = myData.getDataSetByIndex(i)
+        val myData = provider.data ?: return highlightBuffer
+        var i = 0
+        val dataSetCount = myData.dataSetCount
+        while (i < dataSetCount) {
+            val dataSet = myData.getDataSetByIndex(i)
 
-                // don't include DataSets that cannot be highlighted
-                dataSet?.let {
-                    if (!it.isHighlight) {
-                        i++
-                        continue
-                    }
+            dataSet?.let {
+                if (it.isHighlight) {
                     highlightBuffer.addAll(buildHighlights(it, i, xVal, DataSet.Rounding.CLOSEST))
                 }
-
-                i++
             }
+            i++
         }
         return highlightBuffer
     }
@@ -122,52 +113,46 @@ open class ChartHighlighter<T : BarLineScatterCandleBubbleDataProvider<*>>(prote
         rounding: DataSet.Rounding?
     ): MutableList<Highlight> {
         val highlights = ArrayList<Highlight>()
-
         var entries = set.getEntriesForXValue(xVal)?.map { it as EntryFloat }?.toMutableList()
+
         if (entries != null && entries.isEmpty()) {
-            // Try to find closest x-value and take all entries for that x-value
-            val closest: EntryFloat? = set.getEntryForXValue(xVal, Float.NaN, rounding) as? EntryFloat
+            val closest = set.getEntryForXValue(xVal, Float.NaN, rounding) as? EntryFloat
             if (closest != null) {
                 entries = set.getEntriesForXValue(closest.x)?.map { it as EntryFloat }?.toMutableList()
             }
         }
 
-        if (entries != null && entries.isEmpty())
-            return highlights
+        if (entries == null || entries.isEmpty()) return highlights
 
-        if (entries != null)
-            for (e in entries) {
-                val pixels = provider.getTransformer(set.axisDependency)!!.getPixelForValues(e.x, e.y)
-
-                highlights.add(
-                    Highlight(
-                        x = e.x,
-                        y = e.y,
-                        xPx = pixels.x.toFloat(),
-                        yPx = pixels.y.toFloat(),
-                        dataSetIndex = dataSetIndex,
-                        axis = set.axisDependency
-                    )
+        for (e in entries) {
+            val pixels = provider.getTransformer(set.axisDependency)!!.getPixelForValues(e.x, e.y)
+            highlights.add(
+                Highlight(
+                    x = e.x,
+                    y = e.y,
+                    xPx = pixels.x.toFloat(),
+                    yPx = pixels.y.toFloat(),
+                    dataSetIndex = dataSetIndex,
+                    axis = set.axisDependency
                 )
-            }
+            )
+        }
 
         return highlights
     }
 
     /**
-     * Returns the Highlight of the DataSet that contains the closest value on the
-     * y-axis.
-     *
-     * @param closestValues        contains two Highlight objects per DataSet closest to the selected x-position (determined by
-     * rounding up a down)
-     * @param axis                 the closest axis
+     * Selects the closest highlight point based on precise geometric collision bounding checks.
      */
     fun getClosestHighlightByPixel(
         closestValues: MutableList<Highlight>, x: Float, y: Float,
         axis: AxisDependency?, minSelectionDistance: Float
     ): Highlight? {
         var closest: Highlight? = null
-        var distance = minSelectionDistance
+        var shortestDistance = Float.MAX_VALUE
+
+        // Reflection package verification matching your specific Bubble engine implementation strategy
+        val isBubble = provider.javaClass.name.contains("BubbleDataProvider", ignoreCase = true)
 
         for (i in closestValues.indices) {
             val high = closestValues[i]
@@ -175,9 +160,53 @@ open class ChartHighlighter<T : BarLineScatterCandleBubbleDataProvider<*>>(prote
             if (axis == null || high.axis == axis) {
                 val cDistance = getDistance(x, y, high.xPx, high.yPx)
 
-                if (cDistance < distance) {
-                    closest = high
-                    distance = cDistance
+                if (isBubble) {
+                    val dataSet = provider.data?.getDataSetByIndex(high.dataSetIndex) as? info.appdev.charting.interfaces.datasets.IBubbleDataSet
+                    if (dataSet == null) continue
+
+                    val entry = dataSet.getEntryForXValue(high.x, Float.NaN, DataSet.Rounding.CLOSEST)
+                    val bubbleClass = try { Class.forName("info.appdev.charting.data.BubbleEntry") } catch (e: Exception) { null }
+
+                    if (entry != null && bubbleClass?.isInstance(entry) == true) {
+                        val density = (provider as? android.view.View)?.context?.resources?.displayMetrics?.density ?: 1f
+
+                        // 1. SAFE ZOOM SCALE TRACKING VIA BASE CHART VIEW
+                        var currentZoomScale = 1.0f
+                        try {
+                            val viewPortHandlerMethod = provider.javaClass.getMethod("getViewPortHandler")
+                            val viewPortHandler = viewPortHandlerMethod.invoke(provider)
+                            val getScaleXMethod = viewPortHandler?.javaClass?.getMethod("getScaleX")
+                            currentZoomScale = (getScaleXMethod?.invoke(viewPortHandler) as? Float) ?: 1.0f
+                        } catch (e: Exception) {
+                            // Secondary safety fallback if wrapped inside specific view contexts
+                        }
+
+                        // Calculate raw size radius safely dynamically
+                        val getSizeMethod = entry.javaClass.getMethod("getSize")
+                        val rawSize = (getSizeMethod.invoke(entry) as? Float) ?: 0f
+                        val baseRadius = rawSize / 2f
+                        var physicalBubbleRadius = baseRadius * density * currentZoomScale
+
+                        // 2. THE TINY-BUBBLE ACCESSIBILITY BOOST (15dp touch floor target tracking)
+                        val minimumTouchFloor = 15f * density
+                        if (physicalBubbleRadius < minimumTouchFloor) {
+                            physicalBubbleRadius = minimumTouchFloor
+                        }
+
+                        // 3. SELECTION RESOLUTION
+                        if (cDistance <= physicalBubbleRadius) {
+                            if (cDistance < shortestDistance) {
+                                shortestDistance = cDistance
+                                closest = high
+                            }
+                        }
+                    }
+                } else {
+                    // Standard target mapping for Line/Scatter plots
+                    if (cDistance < minSelectionDistance && cDistance < shortestDistance) {
+                        shortestDistance = cDistance
+                        closest = high
+                    }
                 }
             }
         }
@@ -186,14 +215,9 @@ open class ChartHighlighter<T : BarLineScatterCandleBubbleDataProvider<*>>(prote
     }
 
     /**
-     * Calculates the distance between the two given points.
+     * Calculates the distance between two distinct points on the viewport canvas grid.
      */
     protected open fun getDistance(x1: Float, y1: Float, x2: Float, y2: Float): Float {
-        //return Math.abs(y1 - y2);
-        //return Math.abs(x1 - x2);
         return hypot((x1 - x2).toDouble(), (y1 - y2).toDouble()).toFloat()
     }
-
-    protected open val data: ChartData<*>?
-        get() = provider.data
 }

--- a/chartLib/src/main/kotlin/info/appdev/charting/highlight/HorizontalBarHighlighter.kt
+++ b/chartLib/src/main/kotlin/info/appdev/charting/highlight/HorizontalBarHighlighter.kt
@@ -1,6 +1,7 @@
 package info.appdev.charting.highlight
 
 import android.annotation.SuppressLint
+import android.util.Log
 import info.appdev.charting.data.DataSet
 import info.appdev.charting.data.EntryFloat
 import info.appdev.charting.interfaces.dataprovider.BarDataProvider
@@ -9,57 +10,103 @@ import info.appdev.charting.utils.PointD
 import kotlin.math.abs
 
 class HorizontalBarHighlighter(dataProvider: BarDataProvider) : BarHighlighter(dataProvider) {
+
     override fun getHighlight(x: Float, y: Float): Highlight? {
         provider.barData?.let { barData ->
-
+            // In horizontal layouts, the touch engine passes inverted screen projection scales
             val pos = getValsForTouch(y, x)
 
-            val high = getHighlightForX(pos.y.toFloat(), y, x) ?: return null
+            val high = getHighlightForX(pos.y.toFloat(), y, x)
+            if (high == null) {
+                Log.d("HIGHLIGHT", "high is null after getHighlightForX")
+                return null
+            }
 
-            val set = barData.getDataSetByIndex(high.dataSetIndex)
-            if (set != null && set.isStacked) {
-                return getStackedHighlight(
+            val set = barData.getDataSetByIndex(high.dataSetIndex) ?: return null
+
+            if (set.isStacked) {
+                val result = getStackedHighlight(
                     high,
                     set,
                     pos.y.toFloat(),
                     pos.x.toFloat()
                 )
+                Log.d("HIGHLIGHT", "stacked result: ${if (result == null) "NULL" else "x=${result.x} xPx=${result.xPx} yPx=${result.yPx}"}")
+                PointD.recycleInstance(pos)
+                return result
             }
 
-            PointD.recycleInstance(pos)
+            // ─── TRANSLATED DATA-BOUNDS FIX (NON-STACKED HORIZONTAL) ───
+            val entry = set.getEntryForXValue(high.x, high.y)
+            if (entry != null) {
+                // Vertical Category Check: Ensure touch y is within the slot height bounds
+                val barWidthHalf = barData.barWidth / 2f
+                val barBottom = entry.x - barWidthHalf
+                val barTop = entry.x + barWidthHalf
 
+                if (pos.y < barBottom || pos.y > barTop) {
+                    PointD.recycleInstance(pos)
+                    return null
+                }
+
+                // Horizontal Value Length Check: Ensure touch x matches the bar length range
+                val valY = entry.y
+                if (valY >= 0) {
+                    if (pos.x > valY || pos.x < 0) {
+                        PointD.recycleInstance(pos)
+                        return null
+                    }
+                } else {
+                    if (pos.x < valY || pos.x > 0) {
+                        PointD.recycleInstance(pos)
+                        return null
+                    }
+                }
+            }
+            // ─── END OF FIX ───
+
+            PointD.recycleInstance(pos)
+            Log.d("HIGHLIGHT", "Returning high: x=${high.x} y=${high.y}")
             return high
         }
         return null
     }
 
-    override fun buildHighlights(@SuppressLint("RawTypeDataSet") set: IDataSet<*>, dataSetIndex: Int, xVal: Float, rounding: DataSet.Rounding?): MutableList<Highlight> {
+    override fun buildHighlights(
+        @SuppressLint("RawTypeDataSet") set: IDataSet<*>,
+        dataSetIndex: Int,
+        xVal: Float,
+        rounding: DataSet.Rounding?
+    ): MutableList<Highlight> {
         val highlights = ArrayList<Highlight>()
 
         var entries = set.getEntriesForXValue(xVal)?.map { it as EntryFloat }?.toMutableList()
+
         if (entries != null && entries.isEmpty()) {
             // Try to find closest x-value and take all entries for that x-value
-            val closestEntryFloat: EntryFloat? = set.getEntryForXValue(xVal, Float.NaN, rounding) as? EntryFloat
+            val closestEntryFloat = set.getEntryForXValue(xVal, Float.NaN, rounding) as? EntryFloat
             closestEntryFloat?.let { closestE ->
                 entries = set.getEntriesForXValue(closestE.x)?.map { it as EntryFloat }?.toMutableList()
             }
         }
 
-        if (entries != null && entries.isEmpty())
+        if (entries == null || entries.isEmpty())
             return highlights
 
-        if (entries != null)
-            for (entry in entries) {
-                val pixels = provider.getTransformer(set.axisDependency)!!.getPixelForValues(entry.y, entry.x)
+        for (entry in entries!!) {
+            val pixels = provider.getTransformer(set.axisDependency)!!.getPixelForValues(entry.y, entry.x)
 
-                highlights.add(
-                    Highlight(
-                        entry.x, entry.y,
-                        pixels.x.toFloat(), pixels.y.toFloat(),
-                        dataSetIndex, set.axisDependency
-                    )
+            highlights.add(
+                Highlight(
+                    x = entry.x,
+                    y = entry.y,
+                    xPx = pixels.x.toFloat(),
+                    yPx = pixels.y.toFloat(),
+                    dataSetIndex = dataSetIndex,
+                    axis = set.axisDependency
                 )
-            }
+            )
+        }
 
         return highlights
     }

--- a/chartLib/src/main/kotlin/info/appdev/charting/highlight/PieRadarHighlighter.kt
+++ b/chartLib/src/main/kotlin/info/appdev/charting/highlight/PieRadarHighlighter.kt
@@ -1,36 +1,64 @@
 package info.appdev.charting.highlight
 
+import android.view.View
 import info.appdev.charting.charts.PieRadarChartBase
+import kotlin.math.hypot
 
 abstract class PieRadarHighlighter<T : PieRadarChartBase<*>>(protected var chartPieRadar: T) : IHighlighter {
+
     /**
-     * buffer for storing previously highlighted values
+     * Buffer for storing previously highlighted values.
      */
     protected var highlightBuffer: MutableList<Highlight> = ArrayList()
 
     override fun getHighlight(x: Float, y: Float): Highlight? {
         val touchDistanceToCenter = chartPieRadar.distanceToCenter(x, y)
 
-        // check if a slice was touched
-        if (touchDistanceToCenter > chartPieRadar.radius) {
-            // if no slice was touched, highlight nothing
+        // ─── SAFE PROPORTIONAL BOUNDARY FOR PIE CHARTS ───
+        val extendedRadius = chartPieRadar.radius * 1.25f
 
+        // Check if a slice was touched within the expanded boundary
+        if (touchDistanceToCenter > extendedRadius) {
             return null
-        } else {
-            var angle = chartPieRadar.getAngleForPoint(x, y)
+        }
 
+        var angle = chartPieRadar.getAngleForPoint(x, y)
+
+        // ─── TYPE-SAFE PHASE TRANSFORMATION FALLBACK ───
+        // Only modify angle calculations via animation phase adjustments if target is explicitly a PieChart
+        val isPieChart = chartPieRadar.javaClass.name.contains("PieChart", ignoreCase = true)
+        if (isPieChart) {
             angle /= chartPieRadar.animator.phaseY
+        }
 
-            val index = chartPieRadar.getIndexForAngle(angle)
+        val index = chartPieRadar.getIndexForAngle(angle)
 
-            val localData = chartPieRadar.data
-            val maxCount = localData?.maxEntryCountSet?.entryCount ?: 0
-            return if (index !in 0..<maxCount) {
-                null
-            } else {
-                getClosestHighlight(index, x, y)
+        val localData = chartPieRadar.data
+        val maxCount = localData?.maxEntryCountSet?.entryCount ?: 0
+
+        if (index !in 0..<maxCount) {
+            return null
+        }
+
+        val hint = getClosestHighlight(index, x, y)
+
+        // ─── NEW RADAR CHART PROXIMITY FILTER ───
+        // If it's a Radar Chart, enforce a comfortable 40dp finger-sized touch boundary
+        val isRadarChart = chartPieRadar.javaClass.name.contains("RadarChart", ignoreCase = true)
+        if (isRadarChart && hint != null) {
+            val density = (chartPieRadar as View).context.resources.displayMetrics.density
+            val maxSelectionDistance = 40f * density
+
+            // Calculate absolute distance between your touch point and the actual drawn vertex
+            val distanceToVertex = hypot((x - hint.xPx).toDouble(), (y - hint.yPx).toDouble()).toFloat()
+
+            // If your finger is further than 40dp from the actual point, reject the touch registration
+            if (distanceToVertex > maxSelectionDistance) {
+                return null
             }
         }
+
+        return hint
     }
 
     /**
@@ -38,9 +66,7 @@ abstract class PieRadarHighlighter<T : PieRadarChartBase<*>>(protected var chart
      */
     protected abstract fun getClosestHighlight(index: Int, x: Float, y: Float): Highlight?
 
-    override fun getHighlightsAtXValue(
-        xVal: Float,
-        x: Float,
-        y: Float
-    ): MutableList<Highlight>? = null
+    override fun getHighlightsAtXValue(xVal: Float, x: Float, y: Float): MutableList<Highlight>? {
+        return highlightBuffer
+    }
 }

--- a/chartLib/src/main/kotlin/info/appdev/charting/highlight/Range.kt
+++ b/chartLib/src/main/kotlin/info/appdev/charting/highlight/Range.kt
@@ -9,7 +9,7 @@ class Range(var from: Float, var to: Float) {
      * Returns true if this range contains (if the value is in between) the given value, false if not.
      */
     fun contains(value: Float): Boolean {
-        return value > from && value <= to
+        return value >= from && value <= to
     }
 
     fun isLarger(value: Float): Boolean {

--- a/chartLib/src/main/kotlin/info/appdev/charting/highlight/RangeDouble.kt
+++ b/chartLib/src/main/kotlin/info/appdev/charting/highlight/RangeDouble.kt
@@ -5,7 +5,7 @@ package info.appdev.charting.highlight
  * stacked entries. e.g. stack values are -10.0, 5.0, 20.0 -> ranges are (-10 to 0, 0 to 5, 5 to 25).
  */
 class RangeDouble(var from: Double, var to: Double) {
-    fun contains(value: Double): Boolean = value > from && value <= to
+    fun contains(value: Double): Boolean = value >= from && value <= to
     fun isLarger(value: Double): Boolean = value > to
     fun isSmaller(value: Double): Boolean = value < from
 }

--- a/chartLib/src/main/kotlin/info/appdev/charting/renderer/BarChartRenderer.kt
+++ b/chartLib/src/main/kotlin/info/appdev/charting/renderer/BarChartRenderer.kt
@@ -57,13 +57,15 @@ open class BarChartRenderer(
         val barData = dataProvider.barData
         barBuffers = mutableListOf()
 
-        barData?.dataSets?.forEach {
-            barBuffers.add(
-                BarBuffer(
-                    it.entryCount * 4 * (if (it.isStacked) it.stackSize else 1),
-                    barData.dataSetCount, it.isStacked
+        barData?.dataSets?.let { dataSets ->
+            for (dataSet in dataSets) {
+                barBuffers.add(
+                    BarBuffer(
+                        dataSet.entryCount * 4 * (if (dataSet.isStacked) dataSet.stackSize else 1),
+                        barData.dataSetCount, dataSet.isStacked
+                    )
                 )
-            )
+            }
         }
     }
 

--- a/chartLib/src/main/kotlin/info/appdev/charting/renderer/BubbleChartRenderer.kt
+++ b/chartLib/src/main/kotlin/info/appdev/charting/renderer/BubbleChartRenderer.kt
@@ -30,9 +30,11 @@ open class BubbleChartRenderer(
     override fun drawData(canvas: Canvas) {
         val bubbleData = dataProvider.bubbleData
 
-        bubbleData?.dataSets?.forEach { set ->
-            if (set.isVisible)
-                drawDataSet(canvas, set)
+        bubbleData?.dataSets?.let { dataSets ->
+            for (set in dataSets) {
+                if (set.isVisible)
+                    drawDataSet(canvas, set)
+            }
         }
     }
 

--- a/chartLib/src/main/kotlin/info/appdev/charting/renderer/CandleStickChartRenderer.kt
+++ b/chartLib/src/main/kotlin/info/appdev/charting/renderer/CandleStickChartRenderer.kt
@@ -28,9 +28,11 @@ open class CandleStickChartRenderer(
     override fun drawData(canvas: Canvas) {
         val candleData = dataProvider.candleData
 
-        candleData?.dataSets?.forEach { set ->
-            if (set.isVisible)
-                drawDataSet(canvas, set)
+        candleData?.dataSets?.let { dataSets ->
+            for (set in dataSets) {
+                if (set.isVisible)
+                    drawDataSet(canvas, set)
+            }
         }
     }
 

--- a/chartLibCompose/build.gradle.kts
+++ b/chartLibCompose/build.gradle.kts
@@ -1,9 +1,10 @@
-import info.git.versionHelper.getVersionText
+//import info.git.versionHelper.getVersionText
 import org.gradle.kotlin.dsl.implementation
 import java.net.URI
 
 plugins {
     id("com.android.library")
+    id("org.jetbrains.kotlin.android")
     id("maven-publish")
     id("org.jetbrains.kotlin.plugin.compose") version "2.4.0"
     id("com.vanniktech.maven.publish") version "0.37.0"
@@ -17,7 +18,7 @@ android {
 
         // VERSION_NAME no longer available as of 4.1
         // https://issuetracker.google.com/issues/158695880
-        buildConfigField("String", "VERSION_NAME", "\"${getVersionText()}\"")
+        buildConfigField("String", "VERSION_NAME", "\"1.0.0\"")
 
         consumerProguardFiles.add(File("proguard-lib.pro"))
     }
@@ -34,11 +35,6 @@ android {
         buildConfig = true
         compose = true
     }
-    kotlin {
-        compilerOptions {
-            jvmTarget.set(org.jetbrains.kotlin.gradle.dsl.JvmTarget.JVM_17)
-        }
-    }
     testOptions {
         unitTests.isReturnDefaultValues = true // this prevents "not mocked" error
     }
@@ -48,6 +44,12 @@ android {
             // keep it as-is to silence "Unable to strip" warnings.
             keepDebugSymbols += "**/libandroidx.graphics.path.so"
         }
+    }
+}
+
+kotlin {
+    compilerOptions {
+        jvmTarget.set(org.jetbrains.kotlin.gradle.dsl.JvmTarget.JVM_17)
     }
 }
 
@@ -78,7 +80,7 @@ tasks.register<Jar>("androidSourcesJar") {
 }
 
 group = project.findProperty("group")?.toString() ?: "info.AppDevNext"
-var versionVersion = getVersionText()
+var versionVersion = "1.0.0"
 println("Build version $versionVersion")
 
 mavenPublishing {


### PR DESCRIPTION
This is a copy of #791 on upstream.
This enables screenshot compare mechanism @venkatbhoogarbh