### PR TITLE
fix: add setter for rendererXAxis to match rendererLeftYAxis/rendererRightYAxis API

### DIFF
--- a/chartLib/src/main/kotlin/info/appdev/charting/charts/BarLineChartBase.kt
+++ b/chartLib/src/main/kotlin/info/appdev/charting/charts/BarLineChartBase.kt
@@ -1215,8 +1215,14 @@ abstract class BarLineChartBase<T : BarLineScatterCandleBubbleData<IBarLineScatt
         return viewPortHandler.hasNoDragOffset()
     }
 
-    val rendererXAxis: XAxisRenderer
+    /**
+     * Custom axis renderer for the x-axis and overwrites the existing one.
+     */
+    var rendererXAxis: XAxisRenderer
         get() = xAxisRenderer
+        set(rendererXAxis) {
+            xAxisRenderer = rendererXAxis
+        }
 
     /**
      * Custom axis renderer for the left axis and overwrites the existing one.


### PR DESCRIPTION
## Summary

- Converts `rendererXAxis` from a read-only `val` (getter only) to a `var` with both getter and setter in `BarLineChartBase`
- The setter writes to the protected `xAxisRenderer` backing field, following the identical pattern already used by `rendererLeftYAxis` and `rendererRightYAxis`
- Adds KDoc comment on the property consistent with the Y-axis renderer docs

## Why this matters

Issue #782 reports that callers cannot substitute a custom `XAxisRenderer` subclass the same way they can for Y-axis renderers. The asymmetry is a gap in the API: `rendererLeftYAxis` and `rendererRightYAxis` are both `var` with setters, while `rendererXAxis` was `val`. This is a common customization (e.g., custom label formatting or line drawing). The backing field `xAxisRenderer` is already declared `protected var`, so this change requires no visibility changes - only the property accessor needed updating.

## Testing

- Verified the new setter mirrors the `rendererLeftYAxis` setter pattern exactly (backing field assignment)
- Kotlin syntax inspection confirms no errors - `xAxisRenderer` is a `protected var` accepting `XAxisRenderer` assignment
- Full Android Gradle build was not run locally (requires Android SDK); the change is a single property accessor addition with no logic

Fixes #782
